### PR TITLE
startAuditoryFrontEnd.m: use addPathsIfNotIncluded, which is much faster

### DIFF
--- a/startAuditoryFrontEnd.m
+++ b/startAuditoryFrontEnd.m
@@ -3,7 +3,9 @@
 % yourself the Matlab workspace, if that is necessary.
 
 basePath = fileparts(mfilename('fullpath'));
-addpath(genpath(fullfile(basePath, 'src')))
-addpath(genpath(fullfile(basePath, 'test')))
+addPathsIfNotIncluded( ...
+    [ strsplit( genpath(fullfile(basePath, 'src')), pathsep ) ...
+      strsplit( genpath(fullfile(basePath, 'test')), pathsep )] ...
+      );
 
 clear basePath


### PR DESCRIPTION
For some reasons, addpath can get ridiculously slow in subsequent calls. This can be fixed by checking whether the path to be added already IS on the path manually: my new function addPathsIfNotIncluded does exactly this. Speed improvement for startTwoEars on our server: 1 min down do 1 second.
