### PR TITLE
crosscorrelationProc: consistent initialization of output matrix

### DIFF
--- a/src/Processors/crosscorrelationProc.m
+++ b/src/Processors/crosscorrelationProc.m
@@ -156,10 +156,9 @@ classdef crosscorrelationProc < Processor
             end
 
             else
-            out = zeros(max(1,nFrames),nChannels,maxLag*2+1);
+            out = zeros(max(0,nFrames),nChannels,maxLag*2+1);
                 % Use Tobias mex code for framing
                 for jj = 1:nChannels
-
                     % Framing
                     frames_L = frameData(in_l(:,jj),pObj.wSize,pObj.hSize,pObj.win,false);
                     frames_R = frameData(in_r(:,jj),pObj.wSize,pObj.hSize,pObj.win,false);


### PR DESCRIPTION
When processing very small chunks of data nFrames is set to zero. However, there is a discrepancy in how the dimensions of the output matrix are set in the `processChunk()` method from `crosscorrelationProc` vs. the function `frameData()`.

`processChunk()` uses max(1, nFrames) while `frameData()` uses max(0, nFrames) for the first dimension of the output matrix. This is only relevant when the chunk is very small resulting in nFrames < 1.

This changes `processChunk()` to set the first dimension of the output matrix using max(0, nFrames) the same way as done in `frameData()` when padding is switched off.
