### PR TITLE
Fix signal copying

### DIFF
--- a/src/Signals/Signal.m
+++ b/src/Signals/Signal.m
@@ -394,7 +394,7 @@ classdef Signal < matlab.mixin.Copyable
             %               copyElement in those classes!
 
             cpObj = copyElement@matlab.mixin.Copyable(obj);
-            if isa( cpObj.Buf, 'circVBufArray' )
+            if isa( cpObj.Buf, 'circVBuf' )
                 cpObj.setBufferSize( ceil( size( obj.Buf.dat, 1 ) / obj.FsHz ) );
                 cpObj.setData( obj.Data(:) );
             end

--- a/src/Signals/Signal.m
+++ b/src/Signals/Signal.m
@@ -81,7 +81,7 @@ classdef Signal < matlab.mixin.Copyable
             sObj.Name = procHandle.getProcessorInfo.requestName;
             sObj.Label = procHandle.getProcessorInfo.requestLabel;
         end
-        
+
         function setBufferSize( sObj, newBufferSize_s )
             %setBufferSize  This method sets the buffer to a new size,
             %               erasing all data previously stored.
@@ -384,6 +384,20 @@ classdef Signal < matlab.mixin.Copyable
             
         end
         
+    end
+    
+    methods (Access = protected)
+
+        function cpObj = copyElement(obj)
+            %copyElement	Override of Copyable method. Needed because Buf is handle.
+            %               If Subclasses of Signal have private properties, override
+            %               copyElement in those classes!
+
+            cpObj = copyElement@matlab.mixin.Copyable(obj);
+            cpObj.setBufferSize( ceil( size( obj.Buf.dat, 1 ) / obj.FsHz ) );
+            cpObj.setData( obj.Data(:) ); 
+        end
+      
     end
     
     methods (Static)

--- a/src/Signals/Signal.m
+++ b/src/Signals/Signal.m
@@ -394,8 +394,10 @@ classdef Signal < matlab.mixin.Copyable
             %               copyElement in those classes!
 
             cpObj = copyElement@matlab.mixin.Copyable(obj);
-            cpObj.setBufferSize( ceil( size( obj.Buf.dat, 1 ) / obj.FsHz ) );
-            cpObj.setData( obj.Data(:) ); 
+            if isa( cpObj.Buf, 'circVBufArray' )
+                cpObj.setBufferSize( ceil( size( obj.Buf.dat, 1 ) / obj.FsHz ) );
+                cpObj.setData( obj.Data(:) );
+            end
         end
       
     end

--- a/src/Signals/Signal.m
+++ b/src/Signals/Signal.m
@@ -256,7 +256,9 @@ classdef Signal < matlab.mixin.Copyable
             %  blocksize_s : Length of the required data block in seconds
             % backOffset_s : Offset from the end of the signal to the 
             %                requested block's end in seconds (default: 0s)
+            Signal.doShallowCopy( true, true );
             newSobj = sObj.copy();
+            Signal.doShallowCopy( true, false );
             newSobj.Buf = [];
             newSobj.Data = sObj.getSignalBlock( blocksize_s, backOffset_s );
         end
@@ -394,15 +396,29 @@ classdef Signal < matlab.mixin.Copyable
             %               copyElement in those classes!
 
             cpObj = copyElement@matlab.mixin.Copyable(obj);
-            if isa( cpObj.Buf, 'circVBuf' ) && cpObj.Buf.isvalid()
-                cpObj.setBufferSize( ceil( size( obj.Buf.dat, 1 ) / obj.FsHz ) );
-                cpObj.setData( obj.Data(:) );
+            if ~Signal.doShallowCopy
+                if isa( cpObj.Buf, 'circVBuf' ) && cpObj.Buf.isvalid()
+                    cpObj.setBufferSize( ceil( size( obj.Buf.dat, 1 ) / obj.FsHz ) );
+                    cpObj.setData( obj.Data(:) );
+                end
             end
         end
       
     end
     
     methods (Static)
+        
+        function b = doShallowCopy( bSet, newValue )
+            persistent dsc;
+            if isempty( dsc )
+                dsc = false;
+            end
+            if nargin > 0  &&  bSet
+                dsc = newValue;
+            end
+            b = dsc;
+        end
+
         
         function sList = signalList()
             

--- a/src/Signals/Signal.m
+++ b/src/Signals/Signal.m
@@ -394,7 +394,7 @@ classdef Signal < matlab.mixin.Copyable
             %               copyElement in those classes!
 
             cpObj = copyElement@matlab.mixin.Copyable(obj);
-            if isa( cpObj.Buf, 'circVBuf' )
+            if isa( cpObj.Buf, 'circVBuf' ) && cpObj.Buf.isvalid()
                 cpObj.setBufferSize( ceil( size( obj.Buf.dat, 1 ) / obj.FsHz ) );
                 cpObj.setData( obj.Data(:) );
             end


### PR DESCRIPTION
fixed copying; was not creating new instances for the buffer and buffer interface objects.
